### PR TITLE
chore(pkg/dag): resize dot trace leafs

### DIFF
--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -42,8 +42,8 @@ func (n *Node) Attributes() []encoding.Attribute {
 		{Key: "style", Value: dotNodeStyle},
 		{Key: "fillcolor", Value: fillcolor},
 		{Key: "fontsize", Value: fmt.Sprintf("%.3f", 12+(n.Weight*100))},
-		{Key: "width", Value: fmt.Sprintf("%.3f", n.Weight*10)},
-		{Key: "height", Value: fmt.Sprintf("%.3f", n.Weight*10)},
+		{Key: "width", Value: fmt.Sprintf("%.3f", n.Weight*5)},
+		{Key: "height", Value: fmt.Sprintf("%.3f", n.Weight*5)},
 	}
 }
 


### PR DESCRIPTION
This PR makes the DAG DOT stack traces leafs to be resized by half of the previous size, which is relative to its calculated residency fraction for the specific routine.